### PR TITLE
Add instruction step for 'composer install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Development
 1. Set `http://localhost:8000/callback.php` as a "Callback URL" in the newly registered application.
 1. Copy `.env.template` to `.env`.
 1. Set the `CONSUMER_KEY` and `CONSUMER_SECRET` in `.env`.
+1. Run `composer install` to install the dependencies.
 1. Run `./scripts/dev.sh`.
 1. Visit [http://localhost:8000/](http://localhost:8000/).
 


### PR DESCRIPTION
For people not working with PHP regularly (like me) this was something missing in the otherwise very nice and simple development setup steps. :)

Thanks for the great tool and demo @abraham! :tada: 